### PR TITLE
Todo 編集画面の実装

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,11 +2,13 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { TodoListComponent } from './todo/todo-list/todo-list.component';
 import { TodoStoreComponent } from './todo/todo-store/todo-store.component';
+import { TodoEditComponent } from './todo/todo-edit/todo-edit.component';
 
 const routes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'todo/list' },
   { path: 'todo/list', component: TodoListComponent },
   { path: 'todo/store', component: TodoStoreComponent },
+  { path: 'todo/edit/:id', component: TodoEditComponent },
 ]
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,12 +16,14 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ToolbarComponent } from './shared/components/toolbar/toolbar/toolbar.component';
 import { TodoListComponent } from './todo/todo-list/todo-list.component';
 import { TodoStoreComponent } from './todo/todo-store/todo-store.component';
+import { TodoEditComponent } from './todo/todo-edit/todo-edit.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     TodoListComponent,
     TodoStoreComponent,
+    TodoEditComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -27,7 +27,7 @@ export class DataService {
   }
 
   updateTodo(todoUpdate: TodoEdit) {
-    return this.http.post(`${this.BASE_URI}/todo/update`, todoUpdate);
+    return this.http.post(`${this.BASE_URI}/todo/${todoUpdate.id}/update`, todoUpdate);
   }
 }
 

--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -25,18 +25,36 @@ export class DataService {
   storeTodo(todoStore: TodoStore) {
     return this.http.post(`${this.BASE_URI}/todo/store`, todoStore);
   }
+
+  updateTodo(todoUpdate: TodoEdit) {
+    return this.http.post(`${this.BASE_URI}/todo/update`, todoUpdate);
+  }
 }
 
-interface State {
+export interface State {
   code: Number,
   name: String
 }
+
+export const STATUS: State[] = [
+  {code:0, name:'TODO'},
+  {code:1, name:'進行中'},
+  {code:2, name:'完了'}
+]
+
 export interface Todo {
   id:         Number,
   categoryId: Number,
   title:      String,
   body:       String,
   state:      State
+}
+export interface TodoEdit {
+  id:         Number,
+  categoryId: Number,
+  title:      String,
+  body:       String,
+  state:      Number
 }
 export interface Category {
   id:    Number,

--- a/src/app/todo/todo-edit/todo-edit.component.html
+++ b/src/app/todo/todo-edit/todo-edit.component.html
@@ -1,0 +1,1 @@
+<p>todo-edit works!</p>

--- a/src/app/todo/todo-edit/todo-edit.component.html
+++ b/src/app/todo/todo-edit/todo-edit.component.html
@@ -1,1 +1,42 @@
-<p>todo-edit works!</p>
+<div *ngIf="todoCategory">
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Todo 編集</mat-card-title>
+    </mat-card-header>
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <mat-card-content>
+        <mat-form-field>
+          <mat-label>カテゴリ</mat-label>
+          <mat-select formControlName="categoryId">
+            <mat-option *ngFor="let category of categoryList" value={{category.id}}>{{category.name}}</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </mat-card-content>
+      <mat-card-content>
+        <mat-form-field>
+          <mat-label>タイトル</mat-label>
+          <input matInput formControlName="title">
+        </mat-form-field>
+      </mat-card-content>
+      <mat-card-content>
+        <mat-form-field>
+          <mat-label>本文</mat-label>
+          <textarea matInput formControlName="body"></textarea>
+        </mat-form-field>
+      </mat-card-content>
+      <mat-card-content>
+        <mat-form-field>
+          <mat-label>ステータス</mat-label>
+          <mat-select formControlName="state">
+            <mat-option *ngFor="let state of status" value={{state.code}}>{{state.name}}</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </mat-card-content>
+      {{errorMessage}}
+      <mat-card-actions>
+        <button mat-raised-button type="submit" color="primary" [disabled]="form.invalid">更新</button>
+      </mat-card-actions>
+    </form>
+  </mat-card>
+
+</div>

--- a/src/app/todo/todo-edit/todo-edit.component.spec.ts
+++ b/src/app/todo/todo-edit/todo-edit.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TodoEditComponent } from './todo-edit.component';
+
+describe('TodoEditComponent', () => {
+  let component: TodoEditComponent;
+  let fixture: ComponentFixture<TodoEditComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TodoEditComponent]
+    });
+    fixture = TestBed.createComponent(TodoEditComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/todo/todo-edit/todo-edit.component.ts
+++ b/src/app/todo/todo-edit/todo-edit.component.ts
@@ -11,7 +11,7 @@ import { Category, DataService, TodoCategory, STATUS, Todo, TodoEdit } from 'src
 })
 export class TodoEditComponent {
   id?: number;
-  subs: Subscription[] = [];
+  subscription = new Subscription();
   todoCategory?: TodoCategory;
   categoryList: Category[] = [];
   errorMessage?: String;
@@ -32,19 +32,19 @@ export class TodoEditComponent {
   })
 
   ngOnInit(): void {
-    this.subs.push(
+    this.subscription.add(
       this.route.params.subscribe(params => {
         this.id = Number(params['id']);
       })
     );
 
-    this.subs.push(
+    this.subscription.add(
       this.dataService.getCategoryList().subscribe(data => {
         this.categoryList = data;
       })
     );
 
-    this.subs.push(
+    this.subscription.add(
       this.dataService.getTodoCategoryList().subscribe(data => {
         this.todoCategory = data.find(elem => elem.todo.id == this.id);
         console.log(this.todoCategory)
@@ -71,7 +71,7 @@ export class TodoEditComponent {
         body: formData.body ?? "",
         state: Number(formData.state),
       }
-      this.subs.push(
+      this.subscription.add(
         this.dataService.updateTodo(todoData).subscribe({
           next: (_) => {
             this.router.navigate(['todo/list']);
@@ -85,6 +85,6 @@ export class TodoEditComponent {
   }
 
   ngOnDestroy(): void {
-    this.subs.forEach(s => s.unsubscribe());
+    this.subscription.unsubscribe();
   }
 }

--- a/src/app/todo/todo-edit/todo-edit.component.ts
+++ b/src/app/todo/todo-edit/todo-edit.component.ts
@@ -1,4 +1,8 @@
 import { Component } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { Category, DataService, TodoCategory, STATUS, Todo, TodoEdit } from 'src/app/data.service';
 
 @Component({
   selector: 'app-todo-edit',
@@ -6,5 +10,81 @@ import { Component } from '@angular/core';
   styleUrls: ['./todo-edit.component.scss']
 })
 export class TodoEditComponent {
+  id?: number;
+  subs: Subscription[] = [];
+  todoCategory?: TodoCategory;
+  categoryList: Category[] = [];
+  errorMessage?: String;
+  status = STATUS;
 
+  constructor(
+    private route: ActivatedRoute,
+    private dataService: DataService,
+    private builder: FormBuilder,
+    private router: Router,
+  ) {}
+
+  form = this.builder.group({
+    categoryId: ['', Validators.required],
+    title: ['', Validators.required],
+    body: [''],
+    state: ['', Validators.required]
+  })
+
+  ngOnInit(): void {
+    this.subs.push(
+      this.route.params.subscribe(params => {
+        this.id = Number(params['id']);
+      })
+    );
+
+    this.subs.push(
+      this.dataService.getCategoryList().subscribe(data => {
+        this.categoryList = data;
+      })
+    );
+
+    this.subs.push(
+      this.dataService.getTodoCategoryList().subscribe(data => {
+        this.todoCategory = data.find(elem => elem.todo.id == this.id);
+        console.log(this.todoCategory)
+        if(this.todoCategory != undefined){
+          this.form.setValue({
+            categoryId: String(this.todoCategory.todo.categoryId),
+            title: String(this.todoCategory.todo.title),
+            body: String(this.todoCategory.todo.body),
+            state: String(this.todoCategory.todo.state.code)
+          });
+        }
+      })
+    );
+  }
+
+  onSubmit(): void {
+    const formData = this.form.value;
+    console.log(formData)
+    if (this.form.valid){
+      const todoData: TodoEdit = {
+        id: this.id!,
+        categoryId: Number(formData.categoryId!),
+        title: formData.title!,
+        body: formData.body ?? "",
+        state: Number(formData.state),
+      }
+      this.subs.push(
+        this.dataService.updateTodo(todoData).subscribe({
+          next: (_) => {
+            this.router.navigate(['todo/list']);
+          },
+          error: (e) => {
+            this.errorMessage = e.message;
+          }
+        })
+      );
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.subs.forEach(s => s.unsubscribe());
+  }
 }

--- a/src/app/todo/todo-edit/todo-edit.component.ts
+++ b/src/app/todo/todo-edit/todo-edit.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-todo-edit',
+  templateUrl: './todo-edit.component.html',
+  styleUrls: ['./todo-edit.component.scss']
+})
+export class TodoEditComponent {
+
+}

--- a/src/app/todo/todo-list/todo-list.component.html
+++ b/src/app/todo/todo-list/todo-list.component.html
@@ -9,7 +9,7 @@
           </mat-card-header>
           <mat-card-content><p>{{ todoCategory.todo.body }}</p></mat-card-content>
           <mat-card-actions class="button-container">
-            <a mat-icon-button aria-label="Edit"><mat-icon>edit</mat-icon></a>
+            <a mat-icon-button aria-label="Edit" [routerLink]="['/todo/edit', todoCategory.todo.id]"><mat-icon>edit</mat-icon></a>
             <a mat-icon-button aria-label="Delete" (click)="delete(todoCategory.todo)"><mat-icon>delete</mat-icon></a>
           </mat-card-actions>
         </mat-card>


### PR DESCRIPTION
![スクリーンショット 2023-07-25 13 59 59](https://github.com/flutcla/todo-app-api/assets/69044947/93cc9918-2f71-47e2-aa0f-2e1f36079aeb)

実装なのですが、API 側で
https://github.com/flutcla/todo-app/blob/91cfe65b645b928425da50255a4335a31e002bd9/app/json/reads/JsValueTodo.scala#L19
と `enumReads(Todo.Status)` を利用して解釈する場合、request body の state としてはステータスコードのみを渡す必要があるので
https://github.com/flutcla/todo-app-api/blob/3b58bd23beff5244060f70d9d6638eeb7eba2bdc/src/app/data.service.ts#L45-L58
のように2つインターフェースを定義することになってしまい、あまり嬉しくない感じになってしまいました。